### PR TITLE
New feature Custom Playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A small, slick, library independent YouTube User/Playlist player
 * [Default Player Options](http://giorgio003.github.io/Youtube-TV/demos/default.html)
 * [Chromeless Player](http://giorgio003.github.io/Youtube-TV/demos/chromeless.html)
 * [Playlist Support](http://giorgio003.github.io/Youtube-TV/demos/playlists.html)
+* [Custom Playlist Support](http://giorgio003.github.io/Youtube-TV/demos/custom-playlist.html)
 * [Full Screen Player](http://giorgio003.github.io/Youtube-TV/demos/fullscreen.html) (Good for a .tv website?)
 * [jQuery Support](http://giorgio003.github.io/Youtube-TV/demos/jquery.html)
 * [Responsive Support](http://giorgio003.github.io/Youtube-TV/demos/responsive.html)
@@ -101,9 +102,12 @@ If you prefer the `light` theme over the dark, add these 2 options (or mix 'n ma
 ```javascript
 settings = {
     element: null,
+        // Mandatory settings (see below)
     user: null,
     channelId: null,
     playlist: '',
+    videoList: null,
+        // Optional settings
     fullscreen: false,
     accent: '#fff',
     controls: true,
@@ -126,10 +130,16 @@ settings = {
 }
 ```
 
-* `element`: The element or element ID to apply the YouTube TV Player to
+You should choose one of the Mandatory settings:
+
 * `user`: (String) The Username of the YouTube user you want to display videos from
 * `channelId`: (String) The Channel ID of the YouTube channel you want to display videos from (for newer accounts)
-* `playlist`: (String) The Playlist ID(s) you would like to load separated by comma's (Overrides `user`)
+* `playlist`: (String) The Playlist ID(s) you would like to load separated by comma's (Overrides `user` and `videoList`)
+* `videoList`: (String) The Video IDs you would like to load separated by comma's (Overrides `user` and `playlist`)
+
+Other settings:
+
+* `element`: The element or element ID to apply the YouTube TV Player to
 * `browsePlaylists`: (Boolean) If `true` and the specified `user` has YouTube playlists, they will be accessible in the player by clicking the users Username
 * `fullscreen`: (Boolean) If `true`, the player will take up all the available space on the users browser screen
 * `accent`: (String) A CSS color string to apply to the accents of the player

--- a/demos/assets/ytv.css
+++ b/demos/assets/ytv.css
@@ -50,6 +50,9 @@
 	left: 0;
 	-webkit-overflow-scrolling: touch;
 }
+.ytv-list-inner.without-header{
+	top: 0;
+}
 .ytv-list ul{
 	margin: 0;
 	padding: 0;

--- a/demos/custom-playlist.html
+++ b/demos/custom-playlist.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>YouTube TV</title>
+		<link href="assets/ytv.css" type="text/css" rel="stylesheet" />
+		<link href="assets/demo.css" type="text/css" rel="stylesheet" />
+		<style type="text/css">
+			body{
+				margin: 0;
+				padding: 0;
+			}
+		</style>
+	</head>
+	<body class="playlists">
+		
+		<div id="frame"></div>
+		
+		<div class="description">
+			<p>This demo allows users to create a custom playlist based on a list of videos.</p>
+			<p>The <code>videoList</code> is a comma-separated string of <code>VIDEO_ID</code>s.</p>
+			<p>For this case, the header is hidden.</p>
+		</div>
+		
+		<script type="text/javascript" src="assets/ytv.js"></script>
+		<script>
+			window.onload = function(){
+				
+				window.controller = new YTV('frame', {
+					videoList: 'XTTtkisylQw,NZHMKL12rJ4,EAVJrLRBRPY,5Ud-grj4Zl0',
+					autoplay: true,
+					chainVideos: true
+				});
+		
+			};
+		</script>
+	</body>
+</html>

--- a/src/ytv.css
+++ b/src/ytv.css
@@ -50,6 +50,9 @@
 	left: 0;
 	-webkit-overflow-scrolling: touch;
 }
+.ytv-list-inner.without-header{
+	top: 0;
+}
 .ytv-list ul{
 	margin: 0;
 	padding: 0;

--- a/src/ytv.js
+++ b/src/ytv.js
@@ -22,6 +22,7 @@
 				element: null,
 				user: null,
 				channelId: null,
+				videoList: null,
 				fullscreen: false,
 				accent: '#fff',
 				controls: true,
@@ -393,6 +394,84 @@
 							
 						});
 					} else console.log ('Youtube-TV Error: Empty video list');
+				},
+				compileVideoList: function(data){
+					if(data && data.items.length > 0){
+							var list = '',
+								videos = data.items,
+								first = true,
+								i;
+							// settings.channelId = userInfo.items[0].id; 
+							// if(settings.currentPlaylist) user.title += ' &middot; '+(settings.currentPlaylist);
+							if (settings.sortList) videos.sort(function(a,b){if(a.snippet.publishedAt > b.snippet.publishedAt) return -1;if(a.snippet.publishedAt < b.snippet.publishedAt) return 1;return 0;});
+							if (settings.reverseList) videos.reverse();
+							if (settings.shuffleList) {
+								videos = function (){for(var j, x, i = videos.length; i; j = Math.floor(Math.random() * i), x = videos[--i], videos[i] = videos[j], videos[j] = x);return videos;}();
+							}
+
+							list += '<div class="ytv-list-inner"><ul>';
+							for(i=0; i<videos.length; i++){
+								if(videos[i].status.embeddable){
+									var video = {
+										title: videos[i].snippet.title,
+										slug: videos[i].id,
+										link: 'https://www.youtube.com/embed/'+videos[i].id+'&version=3',
+										// link: 'https://www.youtube.com/apiplayer?video_id='+videos[i].id+'&version=3',
+										published: videos[i].snippet.publishedAt,
+										stats: videos[i].statistics,
+										duration: (videos[i].contentDetails.duration),
+										thumb: videos[i].snippet.thumbnails.medium.url
+									};
+									
+									var durationString = video.duration.match(/[0-9]+[HMS]/g);
+									var h = 0, m = 0, s = 0, time = '';
+									durationString.forEach(function (duration) {
+										var unit = duration.charAt(duration.length-1);
+										var amount = parseInt(duration.slice(0,-1));
+										switch (unit) {
+											case 'H': h = (amount > 9 ? '' + amount : '0' + amount); break;
+											case 'M': m = (amount > 9 ? '' + amount : '0' + amount); break;
+											case 'S': s = (amount > 9 ? '' + amount : '0' + amount); break;
+										}
+									});
+									if (h){ time += h+':';}
+									if (m){ time += m+':';} else { time += '00:';}
+									if (s){ time += s;} else { time += '00';}
+									
+									var isFirst = '';
+									if(settings.playId==video.slug){
+										isFirst = ' class="ytv-active"';
+										first = video.slug;
+									} else if(first===true){
+										first = video.slug;
+									}
+
+									list += '<li'+isFirst+'><a href="#" data-ytv="'+(video.slug)+'" class="ytv-clear">';
+									list += '<div class="ytv-thumb"><div class="ytv-thumb-stroke"></div><span>'+(time)+'</span><img src="'+(video.thumb)+'"></div>';
+									list += '<div class="ytv-content"><b>'+(video.title)+'</b>';
+									if (video.stats)
+									{
+										list+='</b><span class="ytv-views">'+utils.addCommas(video.stats.viewCount)+' Views</span>';
+									}
+									list += '</div></a></li>';
+								}
+							}
+							list += '</ul></div>';
+							settings.element.innerHTML = '<div class="ytv-relative"><div class="ytv-video"><div id="ytv-video-player"></div></div><div class="ytv-list">'+list+'</div></div>';
+							if(settings.element.getElementsByClassName('ytv-active').length===0){
+								settings.element.getElementsByTagName('li')[0].className = "ytv-active";
+							}
+							var active = settings.element.getElementsByClassName('ytv-active')[0];
+							active.parentNode.parentNode.scrollTop = active.offsetTop;
+							action.logic.loadVideo(first, settings.autoplay);
+							
+							if (settings.playlist){
+								utils.ajax.get( utils.endpoints.playlistInfo(settings.playlist), prepare.playlists );
+							} else if(settings.browsePlaylists){
+								utils.ajax.get( utils.endpoints.userPlaylists(), prepare.playlists );
+							}
+
+					} else console.log ('Youtube-TV Error: Empty video list');
 				}
 			},
 			action = {
@@ -499,11 +578,14 @@
 				}
 				apiKey = settings.apiKey;
 				settings.element = (typeof id==='string') ? doc.getElementById(id) : id;
-				if(settings.element && (settings.user || settings.channelId || settings.playlist)){
+				if(settings.element && (settings.user || settings.channelId || settings.playlist) || settings.videoList){
 					prepare.youtube();
 					prepare.build();
 					action.bindEvents();
-					if (settings.playlist) {
+					if (settings.videoList) {
+						settings.videoString = settings.videoList;
+						utils.ajax.get( utils.endpoints.videoInfo(), prepare.compileVideoList );
+					} else if (settings.playlist) {
 						utils.ajax.get( utils.endpoints.playlistInfo(settings.playlist), prepare.selectedPlaylist );
 					} else {
 						utils.ajax.get( utils.endpoints.userInfo(), prepare.userUploads );

--- a/src/ytv.js
+++ b/src/ytv.js
@@ -409,7 +409,7 @@
 								videos = function (){for(var j, x, i = videos.length; i; j = Math.floor(Math.random() * i), x = videos[--i], videos[i] = videos[j], videos[j] = x);return videos;}();
 							}
 
-							list += '<div class="ytv-list-inner"><ul>';
+							list += '<div class="ytv-list-inner without-header"><ul>';
 							for(i=0; i<videos.length; i++){
 								if(videos[i].status.embeddable){
 									var video = {


### PR DESCRIPTION
I implemented a new feature, with add a new option +videoList+, a string of comma-separated VIDEO_IDs. That allows users to create a _custom playlist_ of videos, useful when they want to mix videos from different sources.

When using this option, the list header of the playlist will be hidden (as it is not used).
Please the attached demo.

Also updated the Readme, with a more descriptive use of the Settings.

Let me know your thoughts, and feel free to make any changes or comments.
Thank you for your amazing work!

Regards,
Exe
